### PR TITLE
Fix devcontainer build by dropping stale Yarn apt source

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,10 @@ ENV PYTHONUNBUFFERED 1
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
-RUN apt update && apt install -y mariadb-client && apt install -y vim
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends mariadb-client vim \
+  && rm -rf /var/lib/apt/lists/*
 
 # # [Optional] If your requirements rarely change, uncomment this section to add them to the image.
 COPY requirements.txt /tmp/pip-tmp/


### PR DESCRIPTION
## Summary
- The base image (`mcr.microsoft.com/vscode/devcontainers/python:3.9-bullseye`) ships an apt source for the Yarn Debian repo whose GPG key (`62D54FD4003F6525`) no longer verifies. `apt update` aborts as a result, breaking the `mariadb-client` + `vim` install and failing the whole devcontainer build.
- Removes `/etc/apt/sources.list.d/yarn.list` before `apt-get update`. Node is installed via nvm in the prior step, so nothing in this image actually needs the Yarn apt source.
- Also switches `apt` → `apt-get` (stable CLI for scripts), combines the two installs, adds `--no-install-recommends`, and cleans `/var/lib/apt/lists/*` to keep the layer lean.

## Test plan
- [ ] `docker build --build-arg VARIANT=3.9-bullseye --build-arg NODE_VERSION=lts/* -f .devcontainer/Dockerfile .` completes without the `NO_PUBKEY` error.
- [ ] Codespace rebuild ("Codespaces: Full Rebuild Container") succeeds end-to-end.
- [ ] `mariadb` and `vim` are available inside the running container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)